### PR TITLE
Desugar event listener expressions

### DIFF
--- a/src/checker.ts
+++ b/src/checker.ts
@@ -70,6 +70,9 @@ class ExpressionChecker {
   }
 
   private typeOfUnaryExpression(node: ESTree.UnaryExpression): Type {
+    // Check the operand
+    this.typeOf(node.argument)
+
     // https://github.com/Microsoft/TypeScript/blob/v2.3.4/doc/spec.md#4.18
     switch (node.operator) {
       case '-':

--- a/src/desugar.ts
+++ b/src/desugar.ts
@@ -1,0 +1,34 @@
+import * as ESTree from 'estree'
+import { Span } from './diagnostic'
+
+export function desugarListener(exp: ESTree.Expression, native: boolean): ESTree.Expression {
+  // If the expression is identifier, it's a shorthand of `foo($event)`
+  if (exp.type === 'Identifier') {
+    return exp
+  }
+
+  let param: ESTree.Pattern
+  if (native) {
+    // ($event) => exp
+    param = {
+      type: 'Identifier',
+      name: '$event'
+    }
+  } else {
+    // (...arguments) => exp
+    param = {
+      type: 'RestElement',
+      argument: {
+        type: 'Identifier',
+        name: 'arguments'
+      }
+    }
+  }
+
+  return {
+    type: 'ArrowFunctionExpression',
+    expression: true,
+    params: [param],
+    body: exp
+  }
+}

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -7,7 +7,11 @@ export interface Symbol {
 
 export interface SymbolTable {
   getByName(name: string): Symbol | undefined
-  concat(table: SymbolTable): SymbolTable
+  concat(symbols: Symbol[]): SymbolTable
+}
+
+export function createSymbol(name: string, type: Type): Symbol {
+  return { name, type }
 }
 
 export class AnySymbolTable implements SymbolTable {
@@ -20,7 +24,7 @@ export class AnySymbolTable implements SymbolTable {
     }
   }
 
-  concat(table: SymbolTable): SymbolTable {
+  concat(symbols: Symbol[]): SymbolTable {
     return this
   }
 }
@@ -38,12 +42,9 @@ export class SimpleSymbolTable {
     return this.table.get(name)
   }
 
-  concat(table: SimpleSymbolTable | AnySymbolTable): SymbolTable {
-    if (table instanceof AnySymbolTable) return table
-    const symbols: Symbol[] = []
-    this.forEach(value => symbols.push(value))
-    table.forEach(value => symbols.push(value))
-    return new SimpleSymbolTable(symbols)
+  concat(symbols: Symbol[]): SymbolTable {
+    const res = Array.from(this.table.values()).concat(symbols)
+    return new SimpleSymbolTable(res)
   }
 
   forEach(fn: (symbol: Symbol, name: string) => void): void {

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -1,4 +1,4 @@
-import { Type, anyType } from './type'
+import { Type, AnyType } from './type'
 
 export interface Symbol {
   name: string
@@ -11,10 +11,12 @@ export interface SymbolTable {
 }
 
 export class AnySymbolTable implements SymbolTable {
+  constructor(private anyType: AnyType) {}
+
   getByName(name: string): Symbol {
     return {
       name,
-      type: anyType
+      type: this.anyType
     }
   }
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -57,7 +57,7 @@ export class SimpleTypeArguments implements TypeArguments {
 export class AnyType implements Type {
   name = 'any'
   kind = TypeKind.Any
-  members = new AnySymbolTable()
+  members = new AnySymbolTable(this)
   callSignatures = [{
     argTypes: new AnyTypeArguments(),
     returnType: this as AnyType

--- a/test/checker.spec.ts
+++ b/test/checker.spec.ts
@@ -108,6 +108,56 @@ describe('Type Checker', () => {
     })
   })
 
+  describe('arrow function expression', () => {
+    it('should pass an arrow function', () => {
+      test('(foo, { bar }) => foo + bar')
+      test('(foo = 123, [bar], ...baz) => foo + bar + baz[0]')
+    })
+
+    it('should check the function body', () => {
+      test('foo => bar', [
+        {
+          message: `'bar' is not defined`,
+          start: 7,
+          end: 10
+        }
+      ])
+    })
+
+    // esprima does not support async arrow function yet
+    xit('should report an async function', () => {
+      test('async () => 123', [
+        {
+          message: `An async function expression is not allowed in a template`,
+          start: 0,
+          end: 15
+        }
+      ])
+    })
+
+    it('should report an non-expression arrow function', () => {
+      test('() => { 123 }', [
+        {
+          message: `An arrow function that has curly braces is not allowed`,
+          start: 0,
+          end: 13
+        }
+      ])
+    })
+  })
+
+  describe('function expression', () => {
+    it('should always report', () => {
+      test('!function(a, b) { return a + b }', [
+        {
+          message: `Function expression is not allowed in a template, use arrow function expression instead`,
+          start: 1,
+          end: 32
+        }
+      ])
+    })
+  })
+
   describe('unary operator', () => {
     it('should check the operand type', () => {
       test('~(12 - "")', [

--- a/test/checker.spec.ts
+++ b/test/checker.spec.ts
@@ -108,6 +108,18 @@ describe('Type Checker', () => {
     })
   })
 
+  describe('unary operator', () => {
+    it('should check the operand type', () => {
+      test('~(12 - "")', [
+        {
+          message: `The right-hand side of a binary operator '-' must be of type 'number' or 'any'`,
+          start: 7,
+          end: 9
+        }
+      ])
+    })
+  })
+
   describe('binary operator', () => {
     it('should pass a "+" operator with numbers', () => {
       test('1 + 2 + 3')


### PR DESCRIPTION
Added `desugarListener` function that transforms `foo($event)` to `($event) => foo($event)` in `v-on` directives.

Also added arrow function expressions checker so that the function body is checked as same as other expressions. But it's only supported the arrow function without curly braces (`(args) => exp`). Other function expressions are reported by type checker.